### PR TITLE
[FEATURE] Add possibility to exclude fields from being sent to the backend

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,22 @@ routeEnhancers:
 ...
 ```
 
+## Trouble shoot: upload fields
+
+For being able to evaluate the conditions on the backend the form data gets sent as payload to the `conditions.json` route. In case of upload files (a.k.a `[type=file]`) the entire set of selected files are being uploaded with every change of basically every input field. This is resource and time consuming.
+
+In case you don't rely on upload field within your set of conditions you can exclude them from being sent to the backend. To do so just specify add a parameter `data-powermail-cond-excluded-fields-selector` to the form template, e.g.
+
+```xml
+<f:form
+    action="{action}"
+    section="c{ttContentData.uid}"
+    name="field"
+    enctype="multipart/form-data"
+    additionalAttributes="{vh:validation.enableJavascriptValidationAndAjax(form:form, additionalAttributes:{data-powermail-cond-excluded-fields:'.powermail_file'})}"
+>
+```
+
 ## Local Development and Contribution
 There is a docker based local development environment available.
 See [Readme.md](Documentation/ForDevelopers/Readme.md) for more information.


### PR DESCRIPTION
For being able to evaluate the conditions on the backend the form data gets sent as payload to the condition.json route. In case of upload files (a.k.a [type=file]) the entire set of selected files are being uploaded with every change of basically every input field. This is resource and time consuming.

In case you don't rely on upload field within your set of conditions you can exclude them from being sent to the backend. To do so just specify add a parameter data-powermail-cond-excluded-fields-selector to the form template.

Related: #23
Replaces: #59