### PR TITLE
[TASK] Handle missing arguments in ConditionController requests

### DIFF
--- a/Classes/Controller/ConditionController.php
+++ b/Classes/Controller/ConditionController.php
@@ -29,6 +29,12 @@ class ConditionController extends ActionController
     {
         $requestBody = $this->request->getParsedBody();
 
+        if (!isset($requestBody['tx_powermail_pi1'])) {
+            $response = $this->jsonResponse(json_encode([ 'error' => 'Bad Request' ], JSON_THROW_ON_ERROR));
+            $response = $response->withStatus(400);
+            return $response;
+        }
+
         $arguments = $this->conditionService->getArguments($requestBody['tx_powermail_pi1']);
 
         return $this->jsonResponse(json_encode($arguments, JSON_THROW_ON_ERROR));


### PR DESCRIPTION
I have seen #104, but accessing the controller action without the argument at all should just yield a fallback error instead of an exception, and the fix in the other PR (passing an empty array) just leads to another exception down the line).

Fixes #103 
Fixes in2code-pro/powermail_cond#14