### PR TITLE
Attach powermail_condition only to forms with conditions, leave the others alone

### DIFF
--- a/Classes/EventListener/FormActionEventListener.php
+++ b/Classes/EventListener/FormActionEventListener.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace In2code\PowermailCond\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use In2code\Powermail\Events\FormControllerFormActionEvent;
+use In2code\Powermail\Domain\Model\Form;
+use In2code\PowermailCond\Domain\Repository\ConditionContainerRepository;
+
+#[AsEventListener(
+    identifier: 'in2code-de/form-action',
+)]
+final readonly class FormActionEventListener {
+    protected ConditionContainerRepository $conditionContainerRepository;
+
+    public function injectConditionContainerRepository(ConditionContainerRepository $conditionContainerRepository): void
+    {
+        $this->conditionContainerRepository = $conditionContainerRepository;
+    }
+
+    public function __invoke(FormControllerFormActionEvent $event): void
+    {
+        $form = $event->getForm();
+
+        $conditionContainer = $this->conditionContainerRepository->findOneByForm($form->getUid());
+        if ($conditionContainer !== null) {
+            $form->setCss( $form->getCss() . " withConditions");
+        }
+    }
+}

--- a/Resources/Public/JavaScript/PowermailCondition.js
+++ b/Resources/Public/JavaScript/PowermailCondition.js
@@ -340,7 +340,7 @@ class PowermailCondition {
 // the values get checked properly instead of sendFormValuesToPowermailCond
 // receiving a practically empty initial form state.
 window.addEventListener('pageshow', () => {
-  const forms = document.querySelectorAll('.powermail_form');
+  const forms = document.querySelectorAll('.powermail_form.withConditions');
   forms.forEach(function(form) {
     let powermailConditions = new PowermailCondition(form);
     powermailConditions.initialize();


### PR DESCRIPTION
Listening to rendered powermail forms, add a class to the form if it has a condition container attached and only load the frontend part on those.

This prevent a lot of useless traffic/treatment on my site where I have 2 simple forms on every pages and only 1 page in the whole site where I have an actual form with conditions