### PR TITLE
[BUGFIX] static text fields cannot be unhidden

### DIFF
--- a/Classes/Domain/Model/Condition.php
+++ b/Classes/Domain/Model/Condition.php
@@ -271,7 +271,13 @@ class Condition extends AbstractEntity
         // Backup field value if field gets hidden
         if ($action === self::ACTION_HIDE_STRING) {
             $arguments[self::INDEX_BACKUP][$formUid][$pageUid][$fieldMarker] = $field->getText();
-            $field->setText('');
+            // Only clear the value for fields that carry user-submitted input.
+            // Display-only fields (text, html) store their rendered HTML in $text,
+            // not a form value, so clearing it would corrupt the in-memory object
+            // and cause blank output in the template.
+            if (!in_array($field->getType(), ['text', 'html'])) {
+                $field->setText('');
+            }
         }
 
         if (


### PR DESCRIPTION
Static text fields (such as 'text', 'html') don't have a user input, so they shouldn't be emptied and refilled at all.

Resolves: #118